### PR TITLE
feat(ark): support all logging levels (#8)

### DIFF
--- a/volcenginesdkarkruntime/_utils/_logs.py
+++ b/volcenginesdkarkruntime/_utils/_logs.py
@@ -13,12 +13,8 @@ def _basic_config() -> None:
 
 
 def setup_logging() -> None:
-    env = os.environ.get("ARK_LOG")
-    if env == "debug":
+    level = logging.getLevelNamesMapping().get(os.environ.get("ARK_LOG", "").upper())
+    if level is not None:
         _basic_config()
-        logger.setLevel(logging.DEBUG)
-        httpx_logger.setLevel(logging.DEBUG)
-    elif env == "info":
-        _basic_config()
-        logger.setLevel(logging.INFO)
-        httpx_logger.setLevel(logging.INFO)
+        logger.setLevel(level)
+        httpx_logger.setLevel(level)


### PR DESCRIPTION
### About this PR:

观察到 ARK_LOG 只能设置 debug 和 info， 这并不足以关闭 log 显示。该 PR 拓展了可配置的 log 类别，目前所有 https://docs.python.org/3/library/logging.html#levels 支持的 level 均可以配置，不分大小写。

### Example：

这样就能够关闭 SDK 的 log

```python
os.environ["ARK_LOG"] = "CRITICAL"
from volcenginesdkarkruntime import Ark
```