### PR TITLE
fix: no attribute getheader for HTTPResponse

### DIFF
--- a/volcenginesdkcore/rest.py
+++ b/volcenginesdkcore/rest.py
@@ -35,11 +35,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 def log_request(method, url, query_params, headers, body, post_params, request_time_out):


### PR DESCRIPTION
fix 'HTTPHeaderDict' object is not callable

<img width="3124" height="508" alt="image" src="https://github.com/user-attachments/assets/0b3befa8-1dc9-4360-8bcc-b40704afbed9" />
